### PR TITLE
Fix dropout hyperparameter logging

### DIFF
--- a/pgcn/model.py
+++ b/pgcn/model.py
@@ -23,6 +23,7 @@ class PGCN(torch.nn.Module):
         conv_layer2 (HeteroConv): Second heterogeneous graph convolution layer.
         bilinear_decoder (torch.nn.Bilinear): Bilinear layer for link prediction.
         dropout_layer (torch.nn.Dropout): Dropout module.
+        dropout (float): Stored dropout rate for logging.
     """
 
     def __init__(
@@ -38,6 +39,7 @@ class PGCN(torch.nn.Module):
         """
         super().__init__()
         self.dropout_layer = torch.nn.Dropout(p=dropout)
+        self.dropout = dropout
 
         # First heterogeneous graph convolution
         conv_layers1 = {

--- a/pgcn/train_test.py
+++ b/pgcn/train_test.py
@@ -59,7 +59,7 @@ def train(
 
     num_pos = data["gene", "assoc", "disease"].edge_index.size(1)
 
-    # Log hyperparameters
+    # Log hyperparameters (including dropout rate)
     writer.add_hparams(
         {
             "lr": lr,


### PR DESCRIPTION
## Summary
- store the dropout rate on `PGCN` as `self.dropout`
- mention the stored rate in the model docstring
- clarify hyperparameter logging in `train()`

## Testing
- `pytest -q` *(fails: fixture 'model' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68597a63b6348328837940f457c39b7e